### PR TITLE
Fix wildcard description issue in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -212,7 +212,7 @@ You can also use wildcards at the start and/or the end of the document type alia
       "Rules": [ "dog*", "*cat", "*mouse* ]
 ```
 
-This means that all document type aliases ending with "dog", all document types starting with "cat" and all those containing "mouse" will have their URL segments hidden when Umbraco creates URLs for nodes that contain them in the path.
+This means that all document type aliases starting with "dog", all document types ending with "cat" and all those containing "mouse" will have their URL segments hidden when Umbraco creates URLs for nodes that contain them in the path.
 
 ## Other Notes
 


### PR DESCRIPTION
Hi I think the description of the wildcard logic was reversed in the README.md I here is a pull request with a fix, please verify that I'm not mistaken before accepting it.

Best Regards 
Thomas :)